### PR TITLE
Minor fix for extract_url function to allow for text_only flag to function as anticipated

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -285,9 +285,9 @@ def extract_url(url: str, text_only: bool = False) -> List[Chunk]:
                     current_scroll_position += viewport_height
                     page.evaluate(f"window.scrollTo(0, {current_scroll_position})")
                     scrolldowns += 1
-                text = page.inner_text('body')
-                if text:
-                    chunks.append(Chunk(path=url, text=text, image=None, source_type=SourceTypes.URL))
+            text = page.inner_text('body')
+            if text:
+                chunks.append(Chunk(path=url, text=text, image=None, source_type=SourceTypes.URL))
                 browser.close()
     if not chunks:
         raise Exception("Failed to extract any text/images from URL.")


### PR DESCRIPTION
Currently the extract_url function will not output with a text_only flag. This is fixed by adjusting the indentation so the `text` is output no matter the value of the text_only boolean. 

This aligns with the pattern followed by the other extractors.  